### PR TITLE
fix: 处理数据为null情况

### DIFF
--- a/src/data-list.vue
+++ b/src/data-list.vue
@@ -240,7 +240,9 @@ export default {
         let list = _get(data, this.dataPath, [])
 
         // 过滤掉null
-        if (list === null) list = []
+        if (list === null) {
+          list = []
+        }
         if (isDirectionDown) this.list = this.list.concat(list)
         else this.list.unshift(...list)
 

--- a/src/data-list.vue
+++ b/src/data-list.vue
@@ -234,15 +234,12 @@ export default {
 
       try {
         let resp = await this.$axios.get(url + params)
-        let data = resp.data
 
         // 当读取结果为undefined时取默认值[]
-        let list = _get(data, this.dataPath, [])
+        let list = _get(resp.data, this.dataPath, [])
 
         // 过滤掉null
-        if (list === null) {
-          list = []
-        }
+        if (list === null) list = []
         if (isDirectionDown) this.list = this.list.concat(list)
         else this.list.unshift(...list)
 
@@ -255,7 +252,7 @@ export default {
          */
         this.$emit('loaded', [...this.list])
 
-        let totalPages = _get(data, this.totalPagesPath, 0)
+        let totalPages = _get(resp.data, this.totalPagesPath, 0)
         if (isDirectionDown && this.nextPage > totalPages) {
           $state.complete()
           // 防止总页数只有第一页的情况

--- a/src/data-list.vue
+++ b/src/data-list.vue
@@ -236,7 +236,11 @@ export default {
         let resp = await this.$axios.get(url + params)
         let data = resp.data
 
-        const list = _get(data, this.dataPath, [])
+        // 当读取结果为undefined时取默认值[]
+        let list = _get(data, this.dataPath, [])
+
+        // 过滤掉null
+        if (list === null) list = []
         if (isDirectionDown) this.list = this.list.concat(list)
         else this.list.unshift(...list)
 

--- a/src/data-list.vue
+++ b/src/data-list.vue
@@ -236,12 +236,12 @@ export default {
         let resp = await this.$axios.get(url + params)
 
         // 当读取结果为undefined时取默认值[]
-        let list = _get(resp.data, this.dataPath, [])
+        let data = _get(resp.data, this.dataPath, [])
 
         // 过滤掉null
-        if (list === null) list = []
-        if (isDirectionDown) this.list = this.list.concat(list)
-        else this.list.unshift(...list)
+        if (data === null) data = []
+        if (isDirectionDown) this.list = this.list.concat(data)
+        else this.list.unshift(...data)
 
         if (isDirectionDown) this.nextPage++
 


### PR DESCRIPTION
## Why
当后端返回列表数据为null时，组件中的 this.list 也即使用时 slot-scope 中的 list 属性（具体可查看下图）数据为 [null] ，用户循环渲染列表时 读取null的属性时会报错

![image](https://user-images.githubusercontent.com/26338853/57759427-81b68680-772c-11e9-8c88-3ad647086c08.png)

## How
当数据为null时，让list为空数组

## Xmind
![image](https://user-images.githubusercontent.com/26338853/57750815-47da8580-7716-11e9-86e3-6d7f2314eb25.png)

