### PR TITLE
fix: transform const keyword

### DIFF
--- a/build/rollup.config.js
+++ b/build/rollup.config.js
@@ -21,6 +21,7 @@ const config = {
     }),
     babel({
       runtimeHelpers: true,
+      extensions: ['.js', '.jsx', '.es6', '.es', '.mjs', '.vue'],
       exclude: 'node_modules/**'
     })
   ]


### PR DESCRIPTION
# Why
![image](https://user-images.githubusercontent.com/27187946/62818882-3e7b8080-bb80-11e9-8029-cd8e2dc8a070.png)

# How
https://github.com/rollup/rollup-plugin-babel/issues/260#issuecomment-429085745

# Test
**Before**
![Jietu20190810-150240](https://user-images.githubusercontent.com/27187946/62818897-62d75d00-bb80-11e9-8424-a7605dab2e8b.jpg)

**After**
![Jietu20190810-150326](https://user-images.githubusercontent.com/27187946/62818902-72ef3c80-bb80-11e9-8361-395a653a3fdd.jpg)
