### PR TITLE
feat: 支持 slot=spinner

### DIFF
--- a/docs/slot-spinner.md
+++ b/docs/slot-spinner.md
@@ -1,0 +1,25 @@
+```vue
+<template>
+  <div style="height: 400px; overflow: auto">
+    <data-list ref="dataList" :url="url">
+      <ul slot-scope="props">
+        <li v-for="(item, index) in props.list" :key="index">
+          {{item.name}}
+        </li>
+      </ul>
+
+      <div slot="spinner">加载中...</div>
+    </data-list>
+  </div>
+</template>
+
+<script>
+export default {
+  data() {
+    return {
+      url: 'https://easy-mock.com/mock/5c323f1b2188f1589db6af5f/data-list?result=0',
+    }
+  }
+}
+</script>
+```

--- a/src/data-list.md
+++ b/src/data-list.md
@@ -1,0 +1,3 @@
+## Props
+
+支持 vue-infinite-loading 的所有 [props](https://peachscript.github.io/vue-infinite-loading/zh/api/#%E5%B1%9E%E6%80%A7).

--- a/src/data-list.vue
+++ b/src/data-list.vue
@@ -22,6 +22,9 @@
       <div slot="error">
         <slot name="error">网络异常，请刷新重试</slot>
       </div>
+
+      <!--@slot 自定义spinner-->
+      <slot name="spinner" slot="spinner"></slot>
     </infinite-loading>
 
     <!--@slot 自定义列表内容-->
@@ -42,6 +45,8 @@
       <slot name="no-results" slot="no-results">暂时没有数据</slot>
       <!--@slot 该信息将会在加载出现错误时呈现给用户-->
       <slot name="error" slot="error">网络异常，请刷新重试</slot>
+      <!--@slot 自定义spinner-->
+      <slot name="spinner" slot="spinner"></slot>
     </infinite-loading>
   </div>
 </template>


### PR DESCRIPTION
close #57 

![spinner](https://user-images.githubusercontent.com/53422750/63147418-b3433480-c030-11e9-8e09-5bda2d2030f8.gif)

## Why

响应需求

## How

新增 spinner slot，用于传递给 vue-infinite-loading。

## Test

```console
$ jest
 PASS  test/index.test.js
  ✓ main (6ms)

Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
Snapshots:   0 total
Time:        3.443s
Ran all test suites.
```

## Docs

- 补充说明支持 vue-infinite-loading 所有 props。
- 新增 spinner slot 示例
