### PR TITLE
feat: 处理业务异常情况

### DIFF
--- a/docs/throw-custom-error.md
+++ b/docs/throw-custom-error.md
@@ -1,5 +1,5 @@
 
-throw-error-data
+throw-custom-error
 
 ```vue
 <template>

--- a/docs/throw-error-data.md
+++ b/docs/throw-error-data.md
@@ -32,8 +32,10 @@ export default {
      error(e){
       this.errorMsg = e.message
     },
-     throwCustomError(data){
-      return !_get(data, 'payload')
+     throwCustomError(resp){
+       if(!_get(resp, 'payload')){
+         throw resp
+       }
     }
   }
 }

--- a/docs/throw-error-data.md
+++ b/docs/throw-error-data.md
@@ -23,7 +23,7 @@ export default {
     return {
         listConfig:{
            url: 'https://mockapi.eolinker.com/KNhMPAkb444ac06613fc8d63795be9ad0beaf55011936ac/data-list',
-           throwErrorData:this.throwErrorData
+           throwCustomError:this.throwCustomError
         },
        errorMsg:''
     }
@@ -32,10 +32,8 @@ export default {
      error(e){
       this.errorMsg = e.message
     },
-     throwErrorData(data){
-      if(!_get(data, 'payload')){
-       throw new Error(data.msg)
-      }
+     throwCustomError(data){
+      return !_get(data, 'payload')
     }
   }
 }

--- a/docs/throw-error-data.md
+++ b/docs/throw-error-data.md
@@ -1,0 +1,44 @@
+
+throw-error-data
+
+```vue
+<template>
+  <div style="height: 400px; overflow: auto">
+    <data-list ref="dataList" v-bind="listConfig"  @error="error">
+      <!--通过slot-scope从data-list组件获取到返回的数据-->
+      <!-- get list itme data via slot, so you can customize rendering-->
+      <ul slot-scope="props">
+        <li v-for="(item, index) in props.list" :key="index">
+          {{item.name}}
+        </li>
+      </ul>
+      <div slot="error">{{errorMsg}}</div>
+    </data-list>
+  </div>
+</template>
+<script>
+import _get from 'lodash.get'
+export default {
+  data() {
+    return {
+        listConfig:{
+           url: 'https://mockapi.eolinker.com/KNhMPAkb444ac06613fc8d63795be9ad0beaf55011936ac/data-list',
+           throwErrorData:this.throwErrorData
+        },
+       errorMsg:''
+    }
+  },
+  methods:{
+     error(e){
+      this.errorMsg = e.message
+    },
+     throwErrorData(data){
+      if(!_get(data, 'payload')){
+       throw new Error(data.msg)
+      }
+    }
+  }
+}
+</script>
+```
+

--- a/src/data-list.vue
+++ b/src/data-list.vue
@@ -116,6 +116,13 @@ export default {
     saveQuery: {
       type: Boolean,
       default: true
+    },
+    /**
+     * error 特殊处理异常情况
+     */
+    throwErrorData:{
+      type: Function,
+      default: null
     }
   },
   data() {
@@ -195,7 +202,10 @@ export default {
 
       try {
         const {data: resp} = await this.$axios.get(url + queryStr)
-
+        // 特殊处理异常情况
+        if(this.throwErrorData && this.throwErrorData(resp)){
+           throw new Error(resp)
+        }
         // 当读取结果为undefined时取默认值[]
         const data = _get(resp, this.dataPath, [])
         const action = isDirectionDown ? 'push' : 'unshift'

--- a/src/data-list.vue
+++ b/src/data-list.vue
@@ -120,7 +120,7 @@ export default {
     /**
      * error 特殊处理异常情况
      */
-    throwErrorData:{
+    throwCustomError:{
       type: Function,
       default: null
     }
@@ -202,10 +202,8 @@ export default {
 
       try {
         const {data: resp} = await this.$axios.get(url + queryStr)
-        // 特殊处理异常情况
-        if(this.throwErrorData && this.throwErrorData(resp)){
-           throw new Error(resp)
-        }
+        // 处理业务异常情况
+         this.throwCustomError && this.throwCustomError(resp)
         // 当读取结果为undefined时取默认值[]
         const data = _get(resp, this.dataPath, [])
         const action = isDirectionDown ? 'push' : 'unshift'


### PR DESCRIPTION
<!--- 
please use Conventional Commits： https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits
-->

## Why
使用组件过程中，有些业务异常需要显示在error slot，而它们本身 http 状态码是正常的

## How
Describe your steps:
配置参数里传入方法，
```
  listConfig: {
        dataPath: 'payload',
        url: staffList,
        saveQuery:false,
        throwCustomError:this.throwCustomError
      }
```
根据判断来显示异常
```
 throwCustomError(resp){
      if(!_get(resp, 'payload')){
       throw resp
      }
    }
```

## Test
![image](https://user-images.githubusercontent.com/20984729/88158805-0fe6a080-cc3f-11ea-8e75-591fd8a57697.png)

## Docs
It there requires a change to the documentation？
